### PR TITLE
ci(release): Release workflow の Node.js バージョンを '22.21.0' に更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22.5'
+          node-version: '22.21.0'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+# まず全体を除外
+/*
+
+# ただしパッケージのメタデータ・重要ドキュメントは含める
+!/package.json
+!/README.md
+!/README_ja.md
+!/LICENSE
+
+# out 配下は一旦許可（親ディレクトリを残す）
+!/out
+/out/*
+# out 以下では、mcpServer を許可してそれ以外を除外
+!/out/mcpServer
+!/out/mcpServer/**

--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
   "bin": {
     "wbs-manager-mcp": "./out/mcpServer/index.js"
   },
-  "files": [
-    "out/mcpServer/"
-  ],
   "contributes": {
     "commands": [
       {


### PR DESCRIPTION
- `.github/workflows/release.yml` の `node-version` を '22.5' から '22.21.0' に更新。
- 理由: CI 環境とローカル/他ワークフローとの Node バージョン整合性を高めるため。
- 影響: release ワークフローで使用される Node の実行環境が更新されるため、ビルド/公開時の互換性確認を推奨。

Files:
- .github/workflows/release.yml

---

chore(package): package.json の "files" フィールドを削除

- `package.json` 内の `"files": ["out/mcpServer/"]` を削除。
- 理由: npm に含めるファイル指定を `.npmignore` 側で明示的に管理する方針としたため。冗長な設定を除去して公開制御を一元化。
- 影響: パッケージに含めるファイルは `.npmignore` のルールが優先される想定。公開テストを行うことを推奨。

Files:
- package.json

---

chore(release): ルートに .npmignore を追加して npm 公開ファイルを制御

- 新規追加: `.npmignore`
- 内容概略:
  - デフォルトで全て除外 (`/*`) し、`package.json`, `README.md`, `README_ja.md`, `LICENSE` をホワイトリスト。
  - `out` 配下は一旦許可しつつ、`out/mcpServer` 以下を明示的に許可するパターンを追加。
- 理由: npm publish 時に含めるファイルを明確に制御するため。特に配布対象の `out/mcpServer` を意図的に含めるための設定。
- 影響: パッケージ公開時の含有ファイルが `.npmignore` に従うため、公開物の確認（npm pack, npm publish の dry-run など）を実施推奨。

Files:
- .npmignore