### PR TITLE
fix(mcp-server): uuid依存排除とバージョン更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "wbs-manager-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wbs-manager-mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@visactor/vtable": "^1.22.0",
         "@visactor/vtable-gantt": "^1.22.0",
         "markdown-it": "^14.1.0",
-        "uuid": "^9.0.1",
         "vue": "^3.3.4"
       },
       "bin": {
@@ -25,7 +24,6 @@
         "@types/jest": "^29.5.2",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.0",
-        "@types/uuid": "^10.0.0",
         "@types/vscode": "^1.85.0",
         "@typescript-eslint/eslint-plugin": "^8.46.0",
         "@typescript-eslint/parser": "^8.46.0",
@@ -3495,13 +3493,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10828,19 +10819,6 @@
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wbs-manager-mcp",
   "displayName": "WBS MCP",
   "description": "MCP-enabled VS Code extension for Work Breakdown Structure management",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "nojaja",
   "license": "MIT",
   "repository": {
@@ -196,7 +196,6 @@
     "@types/jest": "^29.5.2",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.11.0",
-    "@types/uuid": "^10.0.0",
     "@types/vscode": "^1.85.0",
     "@typescript-eslint/eslint-plugin": "^8.46.0",
     "@typescript-eslint/parser": "^8.46.0",
@@ -225,7 +224,6 @@
     "@visactor/vtable": "^1.22.0",
     "@visactor/vtable-gantt": "^1.22.0",
     "markdown-it": "^14.1.0",
-    "uuid": "^9.0.1",
     "vue": "^3.3.4"
   }
 }

--- a/src/mcpServer/repositories/ArtifactRepository.ts
+++ b/src/mcpServer/repositories/ArtifactRepository.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { Artifact } from '../db/types';
 import { getDatabase } from '../db/connection';
 
@@ -60,7 +61,7 @@ export class ArtifactRepository {
    */
   async createArtifact(title: string, uri?: string, description?: string): Promise<Artifact> {
     const db = await getDatabase();
-    const id = require('uuid').v4();
+    const id = randomUUID();
     const now = new Date().toISOString();
     await db.run(
       `INSERT INTO artifacts (

--- a/src/mcpServer/repositories/CompletionConditionRepository.ts
+++ b/src/mcpServer/repositories/CompletionConditionRepository.ts
@@ -1,5 +1,5 @@
 import type { TaskCompletionCondition, TaskCompletionConditionInput } from '../db/types';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { getDatabase } from '../db/connection';
 
 /**
@@ -30,7 +30,7 @@ export class CompletionConditionRepository {
     description: string
   ): Promise<TaskCompletionCondition> {
     const db = await getDatabase();
-    const id = uuidv4();
+    const id = randomUUID();
     const now = new Date().toISOString();
 
     // task_id毎のorderの最大値を取得し、+1するロジックは呼び出し元で実装
@@ -119,7 +119,7 @@ export class CompletionConditionRepository {
         `INSERT INTO task_completion_conditions (
             id, task_id, description, order_index, created_at, updated_at
          ) VALUES (?, ?, ?, ?, ?, ?)`,
-        uuidv4(),
+        randomUUID(),
         taskId,
         description,
         index,

--- a/src/mcpServer/repositories/DependenciesRepository.ts
+++ b/src/mcpServer/repositories/DependenciesRepository.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { getDatabase } from '../db/connection';
 
 /**
@@ -22,7 +22,7 @@ export class DependenciesRepository {
    */
   async createDependency(dependencyTaskId: string, dependeeTaskId: string, artifacts: string[] | undefined) {
     const db = await getDatabase();
-    const id = uuidv4();
+    const id = randomUUID();
     const now = new Date().toISOString();
 
     // Validate tasks exist to avoid foreign key constraint failures
@@ -49,7 +49,7 @@ export class DependenciesRepository {
         for (const aId of artifacts) {
           await db.run(
             `INSERT INTO dependency_artifacts (id, dependency_id, artifact_id, order_index, created_at) VALUES (?, ?, ?, ?, ?)`,
-            uuidv4(),
+            randomUUID(),
             id,
             aId,
             idx,
@@ -111,7 +111,7 @@ export class DependenciesRepository {
         for (const aId of artifacts) {
           await db.run(
             `INSERT INTO dependency_artifacts (id, dependency_id, artifact_id, order_index, created_at) VALUES (?, ?, ?, ?, ?)`,
-            uuidv4(),
+            randomUUID(),
             dependencyId,
             aId,
             idx,

--- a/src/mcpServer/repositories/TaskArtifactRepository.ts
+++ b/src/mcpServer/repositories/TaskArtifactRepository.ts
@@ -1,5 +1,5 @@
 import type { TaskArtifactAssignment, TaskArtifactRole } from '../db/types';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import { getDatabase } from '../db/connection';
 
 /**
@@ -30,7 +30,7 @@ export class TaskArtifactRepository {
     artifactId: string
   ): Promise<TaskArtifactAssignment> {
     const db = await getDatabase();
-    const id = uuidv4();
+    const id = randomUUID();
     const now = new Date().toISOString();
 
     const defaultRole: TaskArtifactRole = 'deliverable';
@@ -122,7 +122,7 @@ export class TaskArtifactRepository {
         `INSERT INTO task_artifacts (
             id, task_id, artifact_id, role, crud_operations, order_index, created_at, updated_at
          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        uuidv4(),
+        randomUUID(),
         taskId,
         assignment.artifactId,
         role,

--- a/src/mcpServer/repositories/TaskRepository.ts
+++ b/src/mcpServer/repositories/TaskRepository.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'node:crypto';
 import type { Database } from '../db/connection';
 import type {
   Task,
@@ -266,7 +266,7 @@ export class TaskRepository {
     }
   ): Promise<Task> {
     const db = await this.db();
-    const id = uuidv4();
+    const id = randomUUID();
     const now = new Date().toISOString();
     const hasTitle = !!(title && title.toString().trim().length > 0);
     const hasDescription = !!(description && description.toString().trim().length > 0);


### PR DESCRIPTION
- mcpServer配下の各リポジトリでID生成をrandomUUIDへ統一し、ビルトイン機能のみで動作するように変更
- 不要になったuuid/@types/uuid依存を削除し、package-lockを再生成
- バージョンを0.1.4へ更新し、サーバ側の変更がVSIXに反映されるよう調整